### PR TITLE
Rewrite using TCPSocket, proper JSON generation

### DIFF
--- a/lib/chef-handler-sensu-event.rb
+++ b/lib/chef-handler-sensu-event.rb
@@ -48,12 +48,12 @@ class SensuEvent < Chef::Handler
   def create_json
     stringify = run_status.success? ? "ran successfully" : "failed to run"
     severity = run_status.success? ? 0 : @severity
-    hash = {
+    sensu_payload = {
       'handlers' => @handlers,
       'name' => 'chef-run-result',
       'output' => "Chef #{stringify} on #{node.name}",
       'status' => severity }
-    return JSON.generate(hash)
+    return JSON.generate(sensu_payload)
   end
 
   def report


### PR DESCRIPTION
Creates an arbitrary event in Sensu in the event of a failed Chef run. Don't really expect us to use it much but I started this awhile back while messing with the 127.0.0.1:3030 stuff and figured I should just finish it up. Works fine.
